### PR TITLE
Fix: Use `get_stylesheet_directory()` for template overrides

### DIFF
--- a/public/class-addonify-quick-view-public.php
+++ b/public/class-addonify-quick-view-public.php
@@ -442,7 +442,7 @@ class Addonify_Quick_View_Public {
 	public function get_templates( $template_name, $require_once = true, $args=array() ){
 
 		// first look for template in themes/addonify/templates
-		$theme_path = get_template_directory() . '/addonify/' . $template_name .'.php';
+		$theme_path = get_stylesheet_directory() . '/addonify/' . $template_name .'.php';
 		$plugin_path = dirname( __FILE__ ) .'/templates/' . $template_name .'.php';
 
 		if( file_exists( $theme_path ) ){


### PR DESCRIPTION
`get_template_directory()` will only return the path of the parent
theme, whereas `get_stylesheet_directory()` returns the path of the
child theme if there is one.