### PR TITLE
:bug: fix: broken access control.

### DIFF
--- a/addonify-quick-view.php
+++ b/addonify-quick-view.php
@@ -10,10 +10,10 @@
  * Plugin Name:       Addonify - Quick View For WooCommerce
  * Plugin URI:        https://addonify.com/downloads/woocommerce-quick-view/
  * Description:       Addonify WooCommerce Quick View plugin adds functionality to have a WooCommerce product quick preview on a modal window.
- * Version:           2.0.4
+ * Version:           2.0.5
  * Requires at least: 6.4
  * Requires PHP:      7.4
- * Tested up to:      6.8
+ * Tested up to:      6.9.1
  * Author:            Addonify
  * Author URI:        https://addonify.com
  * License:           GPL v2 or later
@@ -34,7 +34,7 @@ if ( ! defined( 'WPINC' ) ) {
  * Start at version 1.0.0 and use SemVer - https://semver.org
  * Rename this for your plugin and update it as you release new versions.
  */
-define( 'ADDONIFY_QUICK_VIEW_VERSION', '2.0.4' );
+define( 'ADDONIFY_QUICK_VIEW_VERSION', '2.0.5' );
 define( 'ADDONIFY_QUICK_VIEW_BASENAME', plugin_basename( __FILE__ ) );
 define( 'ADDONIFY_QUICK_VIEW_DB_INITIALS', 'addonify_qv_' );
 

--- a/includes/udp/class-udp-agent.php
+++ b/includes/udp/class-udp-agent.php
@@ -172,6 +172,11 @@ class Udp_Agent {
 	 * @since    1.0.0
 	 */
 	private function process_user_tracking_choice() {
+		// Verify if the user is logged in and has the capability to manage options.
+		if ( ! is_user_logged_in() || ! current_user_can( 'manage_options' ) ) {
+			wp_safe_redirect( home_url() );
+			exit;
+		}
 
 		$users_choice = isset( $_GET['udp-agent-allow-access'] ) ? sanitize_text_field( wp_unslash( $_GET['udp-agent-allow-access'] ) ) : ''; //phpcs:ignore
 

--- a/readme.txt
+++ b/readme.txt
@@ -5,8 +5,8 @@ Donate link: https://addonify.com/contact/
 Tags:  woocommerce, quick view, woocommerce quick view, products quick view, quickview
 Requires at least: 6.4
 Requires PHP: 7.4
-Tested up to: 6.8
-Stable tag: 2.0.4
+Tested up to: 6.9.1
+Stable tag: 2.0.5
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -154,11 +154,14 @@ Let's make Addonify Quick View better together. We are open to discuss how we ca
 
 == Changelog ==
 
+= 2.0.5 - 15 February, 2026 =
+
+- Fix: Broken Access Control in UDP Agent (CVSS 5.3). Credits to Legion Hunter. Unauthenticated attacker can update option value for "udp_agent_allow_tracking" via "init" hook due to missing authorization and nonce check in it's callback function "on_init".
+
 = 2.0.4 - 25 March, 2025 =
 
 - Tested:  WordPress version 6.8
 - Tested:  WooCommerce version 9.7.1
-
 
 = 2.0.3 - 29 November, 2024 =
 


### PR DESCRIPTION
Fix: Broken Access Control in UDP Agent (CVSS 5.3). Credits to Legion Hunter. Unauthenticated attacker can update option value for "udp_agent_allow_tracking" via "init" hook due to missing authorization and nonce check in it's callback function "on_init".